### PR TITLE
Fix race in e2e tests during waiting for setup pod to be succeeded

### DIFF
--- a/e2e-tests/k8s-e2e-bootstraping.sh
+++ b/e2e-tests/k8s-e2e-bootstraping.sh
@@ -41,8 +41,8 @@ get_pod_name_by_label() {
 }
 
 wait_for_pod() {
-    desired_status=${1:-'Running'}
     set +e
+    desired_status=${1:-'Running'}
     is_pod_in_desired_status=false
     i=1
     while [ "$i" -ne 30 ]

--- a/e2e-tests/k8s-e2e-bootstraping.sh
+++ b/e2e-tests/k8s-e2e-bootstraping.sh
@@ -42,23 +42,23 @@ get_pod_name_by_label() {
 
 wait_for_pod() {
     set +e
-    is_pod_running=false
+    is_pod_in_desired_status=false
     i=1
     while [ "$i" -ne 30 ]
     do
         pod_status="$(kubectl get pod "$1" -o jsonpath='{.status.phase}')"
-        if [ "$pod_status" = "Running" ] || [ "$pod_status" = "Succeeded" ]; then
-            is_pod_running=true
-            printf "pod %s is running\n" "$1"
+        if [ "$pod_status" = "$2" ]; then
+            is_pod_in_desired_status=true
+            printf "pod %s is $2\n" "$1"
             break
         fi
 
-        printf "Waiting for pod %s to be running\n" "$1"
+        printf "Waiting for pod %s to be $2\n" "$1"
         sleep 3
         i=$((i + 1))
     done
-    if [ $is_pod_running = "false" ]; then
-        printf "pod %s does not start within 1 minute 30 seconds\n" "$1"
+    if [ $is_pod_in_desired_status = "false" ]; then
+        printf "pod %s does not transition to $2 within 1 minute 30 seconds\n" "$1"
         kubectl get pods
         kubectl describe pod "$1"
         exit 1

--- a/e2e-tests/k8s-e2e-bootstraping.sh
+++ b/e2e-tests/k8s-e2e-bootstraping.sh
@@ -41,24 +41,25 @@ get_pod_name_by_label() {
 }
 
 wait_for_pod() {
+    desired_status=${1:-'Running'}
     set +e
     is_pod_in_desired_status=false
     i=1
     while [ "$i" -ne 30 ]
     do
         pod_status="$(kubectl get pod "$1" -o jsonpath='{.status.phase}')"
-        if [ "$pod_status" = "$2" ]; then
+        if [ "$pod_status" = "$desired_status" ]; then
             is_pod_in_desired_status=true
-            printf "pod %s is $2\n" "$1"
+            printf "pod %s is $desired_status\n" "$1"
             break
         fi
 
-        printf "Waiting for pod %s to be $2\n" "$1"
+        printf "Waiting for pod %s to be $desired_status\n" "$1"
         sleep 3
         i=$((i + 1))
     done
     if [ $is_pod_in_desired_status = "false" ]; then
-        printf "pod %s does not transition to $2 within 1 minute 30 seconds\n" "$1"
+        printf "pod %s does not transition to $desired_status within 1 minute 30 seconds\n" "$1"
         kubectl get pods
         kubectl describe pod "$1"
         exit 1

--- a/e2e-tests/k8s-e2e-bootstraping.sh
+++ b/e2e-tests/k8s-e2e-bootstraping.sh
@@ -50,16 +50,16 @@ wait_for_pod() {
         pod_status="$(kubectl get pod "$1" -o jsonpath='{.status.phase}')"
         if [ "$pod_status" = "$desired_status" ]; then
             is_pod_in_desired_status=true
-            printf "pod %s is $desired_status\n" "$1"
+            printf "pod %s is %s\n" "$1" "$desired_status"
             break
         fi
 
-        printf "Waiting for pod %s to be $desired_status\n" "$1"
+        printf "Waiting for pod %s to be %s\n" "$1" "$desired_status"
         sleep 3
         i=$((i + 1))
     done
     if [ $is_pod_in_desired_status = "false" ]; then
-        printf "pod %s does not transition to $desired_status within 1 minute 30 seconds\n" "$1"
+        printf "pod %s does not transition to %s within 1 minute 30 seconds\n" "$1" "$desired_status"
         kubectl get pods
         kubectl describe pod "$1"
         exit 1

--- a/e2e-tests/k8s-e2e-bootstraping.sh
+++ b/e2e-tests/k8s-e2e-bootstraping.sh
@@ -42,7 +42,7 @@ get_pod_name_by_label() {
 
 wait_for_pod() {
     set +e
-    desired_status=${1:-'Running'}
+    desired_status=${2:-'Running'}
     is_pod_in_desired_status=false
     i=1
     while [ "$i" -ne 30 ]

--- a/e2e-tests/tests.sh
+++ b/e2e-tests/tests.sh
@@ -32,7 +32,7 @@ if [ "$job_pod_name" = '' ]; then
     kubectl describe job $JOB_NAME
     exit 1
 fi
-wait_for_pod "$job_pod_name"
+wait_for_pod "$job_pod_name" "Succeeded"
 
 printf 'secret:\n'
 kubectl describe secret $SECRET_NAME


### PR DESCRIPTION
The job, as it is by nature, will become `Succeeded` once it finishes. Until then, we won't have any secret created so the test will fail if we do not wait to this to happen.