### PR TITLE
Use add instead of replace in JSON patch for better compatibility

### DIFF
--- a/generate_certificate.sh
+++ b/generate_certificate.sh
@@ -150,7 +150,7 @@ set +e
 # the job will not end until the webhook is patched.
 while true; do
   echo "INFO: Trying to patch webhook adding the caBundle."
-  if kubectl patch mutatingwebhookconfiguration "${webhook}" --type='json' -p "[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value':'${caBundle}'}]"; then
+  if kubectl patch mutatingwebhookconfiguration "${webhook}" --type='json' -p "[{'op': 'add', 'path': '/webhooks/0/clientConfig/caBundle', 'value':'${caBundle}'}]"; then
       break
   fi
   echo "INFO: webhook not patched. Retrying in 5s..."

--- a/generate_certificate.sh
+++ b/generate_certificate.sh
@@ -145,8 +145,9 @@ kubectl create secret tls "${secret}" \
 caBundle=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
 
 set +e
-# patch the webhook adding the caBundle.
-# as the webhook is not created yet (the process should be done manually right after this job is created),
+# Patch the webhook adding the caBundle. It uses an `add` operation to avoid errors in OpenShift because it doesn't set
+# a default value of empty string like Kubernetes. Instead, it doesn't create the caBundle key.
+# As the webhook is not created yet (the process should be done manually right after this job is created),
 # the job will not end until the webhook is patched.
 while true; do
   echo "INFO: Trying to patch webhook adding the caBundle."


### PR DESCRIPTION
In preparation to add support for OpenShift, while testing the JSON patch using a `replace` operation doesn't work:

`
Error from server: jsonpatch replace operation does not apply: doc is missing key: /webhooks/0/clientConfig/caBundle
`

By using the `add` operation we can get the desired behaviour: if the key is already there it will be updated, otherwise it will create the key with the desired value.