### PR TITLE
Add release 1.0.1 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1
+
+### Added
+
+- Better compatibility with Openshift by patching the webhook configuration json with an `add` operation instead of `replace`.
+
 ## 1.0.0
 - Initial version of the Kubernetes Webhook Certificate Manager.


### PR DESCRIPTION
This prepares for the release of version 1.0.1 with improve Openshift compatibility. 

The only commit being included in the release is: 76ac8074e4cf4c2c1213ce467f56fae5d48d3601