### PR TITLE
Proposal: Common name can exceed character limit when service name is appended

### DIFF
--- a/generate_certificate.sh
+++ b/generate_certificate.sh
@@ -77,7 +77,7 @@ DNS.3 = ${service}.${namespace}.svc
 EOF
 
 openssl genrsa -out "${tmpdir}/server-key.pem" 2048
-openssl req -new -key "${tmpdir}/server-key.pem" -subj "/CN=${service}.${namespace}.svc" -out "${tmpdir}/server.csr" -config "${tmpdir}/csr.conf"
+openssl req -new -key "${tmpdir}/server-key.pem" -subj "/CN=${service}" -out "${tmpdir}/server.csr" -config "${tmpdir}/csr.conf"
 
 set +e
 # clean-up any previously created CSR for our service. Ignore errors if not present.


### PR DESCRIPTION
The common name CN is limited in length. By appending the namespace and ".svc"  to the CN its very easy to exceed the limit and cause open SSL to error.

This proposal removes them from the CN (the remain in the SAN)

