### PR TITLE
Use full service domain for the CN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.2
+- Revert to using the full service name for the CN. There is an open issue in 
+  EKS in which the SAN is not added to the signed certificates, making the 
+  TLS requests from the apiserver to the webhook fail.
+  https://github.com/awslabs/amazon-eks-ami/issues/341
+
 ## 1.2.0
 
 - Use a much shorter common name for the certificate (only the Service's name)


### PR DESCRIPTION
EKS is not adding the Subject Alternative Name (SAN) when signing the CSR.
This means that we cannot use service name without specifying the
namespace and `.svc` suffix.

As you can see from the apiserver error message, the TLS certificate
validation is checking only the CN.

x509: certificate is valid for newrelic-metadata-injection-svc, not newrelic-metadata-injection-svc.default.svc

This is a known issue in EKS:

https://github.com/awslabs/amazon-eks-ami/issues/341

This changes revert to using {service}.{namespace}.svc for the CN but
check the length to be withing the limit of 64 characters defined on the
x509 specification.