### PR TITLE
Use fully qualified name for CSRs

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -41,4 +41,3 @@ jobs:
           make e2e-test
         env:
           DOCKER_IMAGE_TAG: e2e-test
-          KUBECTL_VERSION: ${{ matrix.k8s_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,3 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG $DOCKER_IMAGE_NAME:latest
           docker push $DOCKER_IMAGE_NAME:latest
-          


### PR DESCRIPTION
From kubernetes 1.19 onwards, `csr` no longer refers to `certificates.k8s.io/v1beta1`, but `certificates.k8s.io/v1`. This is not compatible with using `kubectl` 1.13, which still leans towards the beta.

This PR makes kubectl explicitly set `certificatesigningrequests.v1beta1.certificates.k8s.io` rather than just `csr`.

Additionally, it also changes the e2e tests to no longer "cheat" on the kubectl version being used, and always go for the one defined in the makefile. This was causing the tests to pass while it wasn't the case in the real world.

Thanks to @baderbuddy for their suggestion on #31.

---
Fixes #31
Closes #32